### PR TITLE
Disallow reserved keywords as identifier names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+0.8.0.2 (unreleased)
+====================
+
+-   Disallow reserved keywords from being used as identifier names.
+
 0.8.0.1 (2016-05-24)
 ====================
 

--- a/language-thrift.cabal
+++ b/language-thrift.cabal
@@ -38,15 +38,16 @@ library
         Language.Thrift.Pretty
         Language.Thrift.Types
     other-modules:
+        Language.Thrift.Internal.Reserved
         Language.Thrift.Internal.Types
         Paths_language_thrift
     default-language: Haskell2010
     build-depends:
         base >= 4.7 && < 5,
         ansi-wl-pprint >= 0.6 && < 0.7,
+        containers >= 0.5 && < 0.6,
         megaparsec >= 4.0 && < 5.0,
         text >= 1.2,
-        containers >= 0.5 && < 0.6,
         transformers
 
 test-suite spec
@@ -55,19 +56,27 @@ test-suite spec
     build-depends:
         base >= 4.7 && < 5,
         ansi-wl-pprint >= 0.6 && < 0.7,
+        containers >= 0.5 && < 0.6,
         megaparsec >= 4.0 && < 5.0,
         text >= 1.2,
+        transformers,
         hspec >= 2.0,
         hspec-discover >= 2.1,
         language-thrift,
         QuickCheck >= 2.5
-    default-language: Haskell2010
-    hs-source-dirs:
-        test
     other-modules:
+        Language.Thrift.Internal.Reserved
+        Language.Thrift.Internal.Types
+        Language.Thrift.Parser
+        Language.Thrift.Pretty
+        Language.Thrift.Types
         Language.Thrift.Arbitrary
         Language.Thrift.ParserSpec
         Language.Thrift.TypesSpec
         Spec
         TestUtils
+    default-language: Haskell2010
+    hs-source-dirs:
+        src,
+        test
     ghc-options: -Wall

--- a/language-thrift.cabal
+++ b/language-thrift.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.13.0.
+-- This file has been generated from package.yaml by hpack version 0.14.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -32,21 +32,22 @@ source-repository head
 library
     hs-source-dirs:
         src
+    ghc-options: -Wall
     exposed-modules:
         Language.Thrift.Parser
         Language.Thrift.Pretty
         Language.Thrift.Types
+    other-modules:
+        Language.Thrift.Internal.Types
+        Paths_language_thrift
+    default-language: Haskell2010
     build-depends:
         base >= 4.7 && < 5,
         ansi-wl-pprint >= 0.6 && < 0.7,
         megaparsec >= 4.0 && < 5.0,
         text >= 1.2,
+        containers >= 0.5 && < 0.6,
         transformers
-    default-language: Haskell2010
-    other-modules:
-        Language.Thrift.Internal.Types
-        Paths_language_thrift
-    ghc-options: -Wall
 
 test-suite spec
     type: exitcode-stdio-1.0

--- a/package.yaml
+++ b/package.yaml
@@ -23,14 +23,13 @@ ghc-options: -Wall
 dependencies:
   - base >= 4.7 && < 5
   - ansi-wl-pprint >= 0.6 && < 0.7
+  - containers >= 0.5 && < 0.6
   - megaparsec >= 4.0 && < 5.0
   - text >= 1.2
+  - transformers
 
 library:
   source-dirs: src
-  dependencies:
-    - containers >= 0.5 && < 0.6
-    - transformers
   exposed-modules:
     - Language.Thrift.Parser
     - Language.Thrift.Pretty
@@ -38,7 +37,7 @@ library:
 
 tests:
   spec:
-    source-dirs: test
+    source-dirs: [src, test]
     main: Main.hs
     dependencies:
       - hspec >= 2.0

--- a/package.yaml
+++ b/package.yaml
@@ -29,6 +29,7 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
+    - containers >= 0.5 && < 0.6
     - transformers
   exposed-modules:
     - Language.Thrift.Parser

--- a/src/Language/Thrift/Internal/Reserved.hs
+++ b/src/Language/Thrift/Internal/Reserved.hs
@@ -1,0 +1,59 @@
+-- |
+-- Module      :  Language.Thrift.Internal.Reserved
+-- Copyright   :  (c) Abhinav Gupta 2016
+-- License     :  BSD3
+--
+-- Maintainer  :  Abhinav Gupta <mail@abhinavg.net>
+-- Stability   :  experimental
+--
+-- This module provides information about reserved Thrift identifiers.
+module Language.Thrift.Internal.Reserved
+    ( isReserved
+    ) where
+
+import           Data.Set (Set)
+import qualified Data.Set as Set
+
+isReserved :: String -> Bool
+isReserved = (`Set.member` reservedKeywords)
+
+reservedKeywords :: Set String
+reservedKeywords = Set.fromList
+    [ "include"
+    , "namespace"
+    , "cpp_namespace"
+    , "php_namespace"
+    , "py_module"
+    , "perl_package"
+    , "ruby_namespace"
+    , "java_package"
+    , "cocoa_package"
+    , "csharp_namespace"
+    , "typedef"
+    , "enum"
+    , "struct"
+    , "union"
+    , "exception"
+    , "required"
+    , "optional"
+    , "senum"
+    , "const"
+    , "string"
+    , "binary"
+    , "slist"
+    , "bool"
+    , "byte"
+    , "i8"
+    , "i16"
+    , "i32"
+    , "i64"
+    , "double"
+    , "map"
+    , "set"
+    , "list"
+    , "service"
+    , "extends"
+    , "oneway"
+    , "void"
+    , "throws"
+    ]

--- a/src/Language/Thrift/Parser.hs
+++ b/src/Language/Thrift/Parser.hs
@@ -64,14 +64,14 @@ module Language.Thrift.Parser
 import Control.Applicative
 import Control.Monad
 import Control.Monad.Trans.State (StateT)
-import Data.Set                  (Set)
 import Data.Text                 (Text)
 
 import qualified Control.Monad.Trans.State as State
-import qualified Data.Set                  as Set
 import qualified Data.Text                 as Text
 import qualified Text.Megaparsec           as P
 import qualified Text.Megaparsec.Lexer     as PL
+
+import Language.Thrift.Internal.Reserved (isReserved)
 
 import qualified Language.Thrift.Types as T
 
@@ -245,7 +245,7 @@ equals = symbolic '='
 -- reservedKeywords list. If it's not, we have a bug and we should crash.
 errorUnlessReserved :: Monad m => String -> m ()
 errorUnlessReserved name =
-    unless (name `Set.member` reservedKeywords) $
+    unless (isReserved name) $
         error ("reserved called with unreserved identifier " ++ show name)
 
 -- | Parses a reserved identifier and adds it to the collection of known
@@ -277,7 +277,7 @@ identifier = P.label "identifier" $ token $ do
     name <- (:)
         <$> (P.letterChar <|> P.char '_')
         <*> many (P.alphaNumChar <|> P.oneOf "_.")
-    when (name `Set.member` reservedKeywords) $
+    when (isReserved name) $
         P.unexpected name
     return (Text.pack name)
 
@@ -636,44 +636,3 @@ typeAnnotation =
 
 optionalSep :: P.Stream s Char => Parser s ()
 optionalSep = void $ optional (comma <|> semi)
-
-reservedKeywords :: Set String
-reservedKeywords = Set.fromList
-    [ "include"
-    , "namespace"
-    , "cpp_namespace"
-    , "php_namespace"
-    , "py_module"
-    , "perl_package"
-    , "ruby_namespace"
-    , "java_package"
-    , "cocoa_package"
-    , "csharp_namespace"
-    , "typedef"
-    , "enum"
-    , "struct"
-    , "union"
-    , "exception"
-    , "required"
-    , "optional"
-    , "senum"
-    , "const"
-    , "string"
-    , "binary"
-    , "slist"
-    , "bool"
-    , "byte"
-    , "i8"
-    , "i16"
-    , "i32"
-    , "i64"
-    , "double"
-    , "map"
-    , "set"
-    , "list"
-    , "service"
-    , "extends"
-    , "oneway"
-    , "void"
-    , "throws"
-    ]

--- a/test/Language/Thrift/Arbitrary.hs
+++ b/test/Language/Thrift/Arbitrary.hs
@@ -17,6 +17,8 @@ import Test.QuickCheck
 
 import qualified Data.Text as Text
 
+import Language.Thrift.Internal.Reserved (isReserved)
+
 import qualified Language.Thrift.Types as T
 
 #ifdef MIN_VERSION_QuickCheck
@@ -64,6 +66,15 @@ instance Arbitrary Docstring where
 
     shrink (Docstring t) = Docstring <$> shrink t
 
+newtype Identifier = Identifier { getIdentifier :: Text }
+    deriving (Show, Typeable, Generic)
+
+instance Arbitrary Identifier where
+    arbitrary = Identifier <$> arbitrary `suchThat` (not . isReserved . Text.unpack)
+
+    shrink (Identifier t) =
+        [Identifier t' | t' <- shrink t, not (isReserved (Text.unpack t'))]
+
 ------------------------------------------------------------------------------
 
 instance Arbitrary (T.Program ()) where
@@ -83,7 +94,11 @@ instance Arbitrary (T.Include ()) where
 
 instance Arbitrary (T.Namespace ()) where
     shrink = genericShrink
-    arbitrary = T.Namespace <$> elements scopes <*> arbitrary <*> pure ()
+    arbitrary =
+        T.Namespace
+            <$> elements scopes
+            <*> (getIdentifier <$> arbitrary)
+            <*> pure ()
       where
         scopes = ["*", "py", "rb", "java", "hs", "cpp"]
 
@@ -101,7 +116,7 @@ instance Arbitrary (T.Const ()) where
     arbitrary =
         T.Const
             <$> arbitrary
-            <*> arbitrary
+            <*> (getIdentifier <$> arbitrary)
             <*> arbitrary
             <*> (getDocstring <$> arbitrary)
             <*> pure ()
@@ -110,8 +125,11 @@ instance Arbitrary (T.Service ()) where
     shrink = genericShrink
     arbitrary =
         T.Service
-            <$> arbitrary
-            <*> arbitrary
+            <$> (getIdentifier <$> arbitrary)
+            <*> frequency
+                    [ (1, return Nothing)
+                    , (3, Just . getIdentifier <$> arbitrary)
+                    ]
             <*> arbitrary
             <*> halfSize arbitrary
             <*> (getDocstring <$> arbitrary)
@@ -123,7 +141,7 @@ instance Arbitrary (T.Function ()) where
         T.Function
             <$> arbitrary
             <*> halfSize arbitrary
-            <*> arbitrary
+            <*> (getIdentifier <$> arbitrary)
             <*> halfSize arbitrary
             <*> halfSize arbitrary
             <*> halfSize arbitrary
@@ -145,7 +163,7 @@ instance Arbitrary (T.Typedef ()) where
     shrink = genericShrink
     arbitrary = T.Typedef
         <$> arbitrary
-        <*> arbitrary
+        <*> (getIdentifier <$> arbitrary)
         <*> halfSize arbitrary
         <*> (getDocstring <$> arbitrary)
         <*> pure ()
@@ -153,7 +171,7 @@ instance Arbitrary (T.Typedef ()) where
 instance Arbitrary (T.Enum ()) where
     shrink = genericShrink
     arbitrary = T.Enum
-        <$> arbitrary
+        <$> (getIdentifier <$> arbitrary)
         <*> arbitrary
         <*> halfSize arbitrary
         <*> (getDocstring <$> arbitrary)
@@ -163,7 +181,7 @@ instance Arbitrary (T.EnumDef ()) where
     shrink = genericShrink
     arbitrary =
         T.EnumDef
-            <$> arbitrary
+            <$> (getIdentifier <$> arbitrary)
             <*> arbitrary
             <*> halfSize arbitrary
             <*> (getDocstring <$> arbitrary)
@@ -172,7 +190,7 @@ instance Arbitrary (T.EnumDef ()) where
 instance Arbitrary (T.Struct ()) where
     shrink = genericShrink
     arbitrary = T.Struct
-        <$> arbitrary
+        <$> (getIdentifier <$> arbitrary)
         <*> arbitrary
         <*> halfSize arbitrary
         <*> (getDocstring <$> arbitrary)
@@ -181,7 +199,7 @@ instance Arbitrary (T.Struct ()) where
 instance Arbitrary (T.Union ()) where
     shrink = genericShrink
     arbitrary = T.Union
-        <$> arbitrary
+        <$> (getIdentifier <$> arbitrary)
         <*> arbitrary
         <*> halfSize arbitrary
         <*> (getDocstring <$> arbitrary)
@@ -190,7 +208,7 @@ instance Arbitrary (T.Union ()) where
 instance Arbitrary (T.Exception ()) where
     shrink = genericShrink
     arbitrary = T.Exception
-        <$> arbitrary
+        <$> (getIdentifier <$> arbitrary)
         <*> arbitrary
         <*> halfSize arbitrary
         <*> (getDocstring <$> arbitrary)
@@ -199,7 +217,7 @@ instance Arbitrary (T.Exception ()) where
 instance Arbitrary (T.Senum ()) where
     shrink = genericShrink
     arbitrary = T.Senum
-        <$> arbitrary
+        <$> (getIdentifier <$> arbitrary)
         <*> arbitrary
         <*> halfSize arbitrary
         <*> (getDocstring <$> arbitrary)
@@ -212,7 +230,7 @@ instance Arbitrary (T.Field ()) where
             <$> (fmap getPositive <$> arbitrary)
             <*> arbitrary
             <*> halfSize arbitrary
-            <*> arbitrary
+            <*> (getIdentifier <$> arbitrary)
             <*> halfSize arbitrary
             <*> halfSize arbitrary
             <*> (getDocstring <$> arbitrary)
@@ -221,7 +239,8 @@ instance Arbitrary (T.Field ()) where
 instance Arbitrary (T.TypeReference ()) where
     shrink = genericShrink
     arbitrary = oneof
-        [ T.DefinedType           <$> arbitrary <*> pure ()
+        [ T.DefinedType           <$> (getIdentifier <$> arbitrary)
+                                  <*> pure ()
         , halfSize $ T.StringType <$> arbitrary <*> pure ()
         , halfSize $ T.BinaryType <$> arbitrary <*> pure ()
         , halfSize $ T.SListType  <$> arbitrary <*> pure ()
@@ -242,7 +261,7 @@ instance Arbitrary T.FieldRequiredness where
 
 instance Arbitrary T.TypeAnnotation where
     shrink = genericShrink
-    arbitrary = T.TypeAnnotation <$> arbitrary <*> arbitrary
+    arbitrary = T.TypeAnnotation <$> (getIdentifier <$> arbitrary) <*> arbitrary
 
 
 newtype BasicConstValue = BasicConstValue {
@@ -256,7 +275,8 @@ instance Arbitrary BasicConstValue where
         [ T.ConstFloat      <$> choose (0.0, 10000.0) <*> pure ()
         , T.ConstInt        <$> arbitrary <*> pure ()
         , T.ConstLiteral    <$> arbitrary <*> pure ()
-        , T.ConstIdentifier <$> arbitrary <*> pure ()
+        , T.ConstIdentifier <$> (getIdentifier <$> arbitrary)
+                            <*> pure ()
         ]
 
 -- | newtype wrapper around const values so that we're not generating lists

--- a/test/Language/Thrift/ParserSpec.hs
+++ b/test/Language/Thrift/ParserSpec.hs
@@ -80,6 +80,13 @@ testParseFailure = do
         , "something_else<foo>"
         ]
 
+    it "cannot parse reserved keywords in names" $
+        parseFailureCases P.program
+            [ "enum struct {}"
+            , "strut Foo { 1: required string service }"
+            ]
+
+
 parseFailureCases :: Show a => Parser a -> [String] -> Expectation
 parseFailureCases p = mapM_ (p `shouldNotParse`)
 


### PR DESCRIPTION
This fixes a bug where we would allow declarations like the following,

    struct enum {}
    struct foo { 1: string service }