### PR TITLE
[0.9] Disallow reserved keywords in identifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+0.9.0.2 (unreleased)
+====================
+
+-   Disallow reserved keywords from being used as identifier names.
+
 0.9.0.1 (2016-05-26)
 ====================
 
@@ -8,6 +13,11 @@
 
 - Deprecate the `Language.Thrift.Types` in favor of `Language.Thrift.AST`.
 - Upgrade to `megaparsec` 5.0.
+
+0.8.0.2 (2016-08-31)
+====================
+
+-   Disallow reserved keywords from being used as identifier names.
 
 0.8.0.1 (2016-05-24)
 ====================

--- a/language-thrift.cabal
+++ b/language-thrift.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.13.0.
+-- This file has been generated from package.yaml by hpack version 0.14.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -36,9 +36,11 @@ library
     build-depends:
         base >= 4.7 && < 5,
         ansi-wl-pprint >= 0.6 && < 0.7,
+        containers >= 0.5 && < 0.6,
         megaparsec >= 5.0 && < 6.0,
-        text >= 1.2,
         scientific >= 0.3 && < 0.4,
+        semigroups >= 0.18 && < 0.19,
+        text >= 1.2,
         transformers
     exposed-modules:
         Language.Thrift.AST
@@ -48,6 +50,7 @@ library
     other-modules:
         Language.Thrift.Internal.AST
         Language.Thrift.Internal.Lens
+        Language.Thrift.Internal.Reserved
         Paths_language_thrift
     default-language: Haskell2010
 
@@ -55,18 +58,30 @@ test-suite spec
     type: exitcode-stdio-1.0
     main-is: Main.hs
     hs-source-dirs:
+        src,
         test
     ghc-options: -Wall
     build-depends:
         base >= 4.7 && < 5,
         ansi-wl-pprint >= 0.6 && < 0.7,
+        containers >= 0.5 && < 0.6,
         megaparsec >= 5.0 && < 6.0,
+        scientific >= 0.3 && < 0.4,
+        semigroups >= 0.18 && < 0.19,
         text >= 1.2,
+        transformers,
         hspec >= 2.0,
         hspec-discover >= 2.1,
         language-thrift,
         QuickCheck >= 2.5
     other-modules:
+        Language.Thrift.AST
+        Language.Thrift.Internal.AST
+        Language.Thrift.Internal.Lens
+        Language.Thrift.Internal.Reserved
+        Language.Thrift.Parser
+        Language.Thrift.Pretty
+        Language.Thrift.Types
         Language.Thrift.Arbitrary
         Language.Thrift.ASTSpec
         Language.Thrift.ParserSpec

--- a/package.yaml
+++ b/package.yaml
@@ -23,14 +23,15 @@ ghc-options: -Wall
 dependencies:
   - base >= 4.7 && < 5
   - ansi-wl-pprint >= 0.6 && < 0.7
+  - containers >= 0.5 && < 0.6
   - megaparsec >= 5.0 && < 6.0
+  - scientific >= 0.3 && < 0.4
+  - semigroups >= 0.18 && < 0.19
   - text >= 1.2
+  - transformers
 
 library:
   source-dirs: src
-  dependencies:
-    - scientific >= 0.3 && < 0.4
-    - transformers
   exposed-modules:
     - Language.Thrift.AST
     - Language.Thrift.Parser
@@ -39,7 +40,7 @@ library:
 
 tests:
   spec:
-    source-dirs: test
+    source-dirs: [src, test]
     main: Main.hs
     dependencies:
       - hspec >= 2.0

--- a/src/Language/Thrift/Internal/Reserved.hs
+++ b/src/Language/Thrift/Internal/Reserved.hs
@@ -1,0 +1,59 @@
+-- |
+-- Module      :  Language.Thrift.Internal.Reserved
+-- Copyright   :  (c) Abhinav Gupta 2016
+-- License     :  BSD3
+--
+-- Maintainer  :  Abhinav Gupta <mail@abhinavg.net>
+-- Stability   :  experimental
+--
+-- This module provides information about reserved Thrift identifiers.
+module Language.Thrift.Internal.Reserved
+    ( isReserved
+    ) where
+
+import           Data.Set (Set)
+import qualified Data.Set as Set
+
+isReserved :: String -> Bool
+isReserved = (`Set.member` reservedKeywords)
+
+reservedKeywords :: Set String
+reservedKeywords = Set.fromList
+    [ "include"
+    , "namespace"
+    , "cpp_namespace"
+    , "php_namespace"
+    , "py_module"
+    , "perl_package"
+    , "ruby_namespace"
+    , "java_package"
+    , "cocoa_package"
+    , "csharp_namespace"
+    , "typedef"
+    , "enum"
+    , "struct"
+    , "union"
+    , "exception"
+    , "required"
+    , "optional"
+    , "senum"
+    , "const"
+    , "string"
+    , "binary"
+    , "slist"
+    , "bool"
+    , "byte"
+    , "i8"
+    , "i16"
+    , "i32"
+    , "i64"
+    , "double"
+    , "map"
+    , "set"
+    , "list"
+    , "service"
+    , "extends"
+    , "oneway"
+    , "void"
+    , "throws"
+    ]

--- a/test/Language/Thrift/ParserSpec.hs
+++ b/test/Language/Thrift/ParserSpec.hs
@@ -80,6 +80,13 @@ testParseFailure = do
         , "something_else<foo>"
         ]
 
+    it "cannot parse reserved keywords in names" $
+        parseFailureCases P.program
+            [ "enum struct {}"
+            , "strut Foo { 1: required string service }"
+            ]
+
+
 parseFailureCases :: Show a => Parser a -> [String] -> Expectation
 parseFailureCases p = mapM_ (p `shouldNotParse`)
 


### PR DESCRIPTION
This is a port of #4 for 0.9.