### PR TITLE
refactor: Migrate to prettyprinter

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Haskell
-        uses: haskell/actions/setup@v1
+        uses: haskell-actions/setup@v2
         with:
           cabal-version: latest
           ghc-version: ${{ matrix.ghc }}

--- a/language-thrift.cabal
+++ b/language-thrift.cabal
@@ -43,12 +43,12 @@ library
       Paths_language_thrift
   hs-source-dirs:
       src
-  ghc-options: -Wall
+  ghc-options: -Wall -Wunused-packages
   build-depends:
-      ansi-wl-pprint ==0.6.*
-    , base >=4.7 && <5
+      base >=4.7 && <5
     , containers >=0.5 && <0.7
     , megaparsec >=9.0 && <10.0
+    , prettyprinter-compat-ansi-wl-pprint >=1.0 && <2.0
     , scientific ==0.3.*
     , semigroups >=0.18 && <0.21
     , text >=1.2
@@ -61,12 +61,12 @@ test-suite spec
   hs-source-dirs:
       src
       test
-  ghc-options: -Wall
+  ghc-options: -Wall -Wunused-packages
   build-tool-depends:
       hspec-discover:hspec-discover >=2.1
   build-depends:
       QuickCheck >=2.5
-    , ansi-wl-pprint ==0.6.*
+    , prettyprinter-compat-ansi-wl-pprint >=1.0 && <2.0
     , base >=4.7 && <5
     , containers >=0.5 && <0.7
     , hspec >=2.0

--- a/package.yaml
+++ b/package.yaml
@@ -22,9 +22,9 @@ ghc-options: -Wall
 
 dependencies:
   - base >= 4.7 && < 5
-  - ansi-wl-pprint >= 0.6 && < 0.7
   - containers >= 0.5 && < 0.7
   - megaparsec >= 9.0 && < 10.0
+  - prettyprinter-compat-ansi-wl-pprint >= 1.0 && < 2.0
   - scientific >= 0.3 && < 0.4
   - semigroups >= 0.18 && < 0.21
   - text >= 1.2

--- a/src/Language/Thrift/Parser.hs
+++ b/src/Language/Thrift/Parser.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
 -- |
 -- Module      :  Language.Thrift.Parser
 -- Copyright   :  (c) Abhinav Gupta 2016
@@ -38,6 +39,7 @@ module Language.Thrift.Parser
     , include
     , namespace
 
+    , functionParameters
     , definition
     , constant
     , typeDefinition
@@ -200,7 +202,7 @@ docstring = do
     indent <- fromIntegral . P.unPos <$> PL.indentLevel
     isNewLine <- maybeEOL
     chunks <- loop isNewLine (indent - 1) []
-    return $! Text.intercalate "\n" chunks
+    return $! Text.intercalate "\n" (Text.dropWhileEnd (== ' ') <$> chunks)
   where
     maybeEOL = (PC.eol >> return True) <|> return False
 
@@ -639,11 +641,15 @@ function = withDocstring $
         <$> ((reserved "oneway" $> True) <|> pure False)
         <*> ((reserved "void" $> Nothing) <|> Just <$> typeReference)
         <*> identifier
-        <*> parens (many field)
+        <*> functionParameters
         <*> optional (reserved "throws" *> parens (many field))
         <*> typeAnnotations
         <*  optionalSep
 
+functionParameters
+    :: (P.TraversableStream s, P.Token s ~ Char)
+    => Parser s [T.Field P.SourcePos]
+functionParameters = parens $ many field
 
 -- | Type annotations on entitites.
 --

--- a/src/Language/Thrift/Pretty.hs
+++ b/src/Language/Thrift/Pretty.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 -- |
 -- Module      :  Language.Thrift.Pretty
 -- Copyright   :  (c) Abhinav Gupta 2016
@@ -37,6 +37,7 @@ module Language.Thrift.Pretty
     , include
     , namespace
 
+    , functionParameters
     , definition
     , constant
     , typeDefinition
@@ -64,12 +65,12 @@ module Language.Thrift.Pretty
 import Prelude hiding ((<$>))
 #endif
 
+import qualified Data.List as List
 import           Data.Text (Text)
 import qualified Data.Text as Text
 
 import Text.PrettyPrint.ANSI.Leijen
     ( Doc
-    , Pretty (..)
     , align
     , bold
     , cyan
@@ -79,6 +80,7 @@ import Text.PrettyPrint.ANSI.Leijen
     , empty
     , enclose
     , group
+    , hardline
     , hcat
     , hsep
     , integer
@@ -93,11 +95,10 @@ import Text.PrettyPrint.ANSI.Leijen
     , (<$$>)
     , (<$>)
     , (<+>)
-    , (<>)
     )
 
+import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import qualified Language.Thrift.Internal.AST as T
-import qualified Text.PrettyPrint.ANSI.Leijen as P
 
 -- | Configuration for the pretty printer.
 data Config = Config
@@ -127,38 +128,23 @@ program c T.Program{..} =
         else vsep (map header programHeaders) <$> line
     ) <> map (definition c) programDefinitions `sepBy` (line <> line)
 
-instance Pretty (T.Program a) where
-    pretty = program defaultConfig
-
 -- | Print the headers for a program.
 header :: T.Header ann -> Doc
 header (T.HeaderInclude inc)  = include inc
 header (T.HeaderNamespace ns) = namespace ns
 
-instance Pretty (T.Header a) where
-    pretty = header
-
 include :: T.Include ann -> Doc
 include T.Include{..} = reserved "include" <+> literal includePath
-
-instance Pretty (T.Include a) where
-    pretty = include
 
 namespace :: T.Namespace ann -> Doc
 namespace T.Namespace{..} = hsep
     [reserved "namespace", text namespaceLanguage, text namespaceName]
-
-instance Pretty (T.Namespace a) where
-    pretty = namespace
 
 -- | Print a constant, type, or service definition.
 definition :: Config -> T.Definition ann -> Doc
 definition c (T.ConstDefinition cd)  = constant c cd
 definition c (T.TypeDefinition def)  = typeDefinition c def
 definition c (T.ServiceDefinition s) = service c s
-
-instance Pretty (T.Definition a) where
-    pretty = definition defaultConfig
 
 constant :: Config -> T.Const ann -> Doc
 constant c T.Const{..} = constDocstring $$ hsep
@@ -168,9 +154,6 @@ constant c T.Const{..} = constDocstring $$ hsep
     , equals
     , constantValue c constValue
     ]
-
-instance Pretty (T.Const a) where
-    pretty = constant defaultConfig
 
 service :: Config -> T.Service ann -> Doc
 service c@Config{indentWidth} T.Service{..} =
@@ -183,18 +166,18 @@ service c@Config{indentWidth} T.Service{..} =
       Nothing   -> empty
       Just name -> space <> reserved "extends" <+> text name
 
-instance Pretty (T.Service a) where
-    pretty = service defaultConfig
+functionParameters :: Config -> [T.Field ann] -> Doc
+functionParameters c@Config{..}
+  = encloseSep indentWidth lparen rparen comma
+  . map (field c)
 
 -- | Pretty print a function definition.
 --
 function :: Config -> T.Function ann -> Doc
-function c@Config{indentWidth} T.Function{..} = functionDocstring $$
-  oneway <> returnType <+> text functionName <>
-    encloseSep
-        indentWidth lparen rparen comma
-        (map (field c) functionParameters) <>
-    exceptions <> typeAnnots c functionAnnotations <> semi
+function c@Config{indentWidth} T.Function{functionParameters = params, ..} = functionDocstring $$
+  oneway <> returnType <+> text functionName
+    <> functionParameters c params
+    <> exceptions <> typeAnnots c functionAnnotations <> semi
   where
     exceptions = case functionExceptions of
       Nothing -> empty
@@ -208,9 +191,6 @@ function c@Config{indentWidth} T.Function{..} = functionDocstring $$
           then reserved "oneway" <> space
           else empty
 
-instance Pretty (T.Function a) where
-    pretty = function defaultConfig
-
 typeDefinition :: Config -> T.Type ann -> Doc
 typeDefinition c td = case td of
   T.TypedefType   t -> c `typedef`   t
@@ -218,25 +198,16 @@ typeDefinition c td = case td of
   T.StructType    t -> c `struct`    t
   T.SenumType     t -> c `senum`     t
 
-instance Pretty (T.Type a) where
-    pretty = typeDefinition defaultConfig
-
 typedef :: Config -> T.Typedef ann -> Doc
 typedef c T.Typedef{..} = typedefDocstring $$
     reserved "typedef" <+> typeReference c typedefTargetType <+>
     declare typedefName <> typeAnnots c typedefAnnotations
-
-instance Pretty (T.Typedef a) where
-    pretty = typedef defaultConfig
 
 enum :: Config -> T.Enum ann -> Doc
 enum c@Config{indentWidth} T.Enum{..} = enumDocstring $$
     reserved "enum" <+> declare enumName <+>
       block indentWidth (comma <> line) (map (enumValue c) enumValues)
     <> typeAnnots c enumAnnotations
-
-instance Pretty (T.Enum a) where
-    pretty = enum defaultConfig
 
 struct :: Config -> T.Struct ann -> Doc
 struct c@Config{indentWidth} T.Struct{..} = structDocstring $$
@@ -248,9 +219,6 @@ struct c@Config{indentWidth} T.Struct{..} = structDocstring $$
         T.StructKind    -> reserved "struct"
         T.UnionKind     -> reserved "union"
         T.ExceptionKind -> reserved "exception"
-
-instance Pretty (T.Struct a) where
-    pretty = struct defaultConfig
 
 union :: Config -> T.Struct ann -> Doc
 union = struct
@@ -265,9 +233,6 @@ senum c@Config{indentWidth} T.Senum{..} = senumDocstring $$
     reserved "senum" <+> declare senumName <+>
       encloseSep indentWidth lbrace rbrace comma (map literal senumValues)
     <> typeAnnots c senumAnnotations
-
-instance Pretty (T.Senum a) where
-    pretty = senum defaultConfig
 
 field :: Config -> T.Field ann -> Doc
 field c T.Field{..} = fieldDocstring $$ hcat
@@ -286,15 +251,9 @@ field c T.Field{..} = fieldDocstring $$ hcat
     , typeAnnots c fieldAnnotations
     ]
 
-instance Pretty (T.Field a) where
-    pretty = field defaultConfig
-
 requiredness :: T.FieldRequiredness -> Doc
 requiredness T.Optional = reserved "optional"
 requiredness T.Required = reserved "required"
-
-instance Pretty T.FieldRequiredness where
-    pretty = requiredness
 
 enumValue :: Config -> T.EnumDef ann -> Doc
 enumValue c T.EnumDef{..} = enumDefDocstring $$
@@ -303,9 +262,6 @@ enumValue c T.EnumDef{..} = enumDefDocstring $$
     value = case enumDefValue of
       Nothing -> empty
       Just v  -> space <> equals <+> integer v
-
-instance Pretty (T.EnumDef a) where
-    pretty = enumValue defaultConfig
 
 -- | Pretty print a field type.
 typeReference :: Config -> T.TypeReference ann -> Doc
@@ -336,9 +292,6 @@ typeReference c ft = case ft of
         <> enclose langle rangle (typeReference c v)
         <> typeAnnots c anns
 
-instance Pretty (T.TypeReference a) where
-    pretty = typeReference defaultConfig
-
 -- | Pretty print a constant value.
 constantValue :: Config -> T.ConstValue ann -> Doc
 constantValue c@Config{indentWidth} value = case value of
@@ -351,9 +304,6 @@ constantValue c@Config{indentWidth} value = case value of
   T.ConstMap       vs _ ->
     encloseSep indentWidth lbrace rbrace comma $
       map (\(k, v) -> constantValue c k <> colon <+> constantValue c v) vs
-
-instance Pretty (T.ConstValue a) where
-    pretty = constantValue defaultConfig
 
 typeAnnots :: Config -> [T.TypeAnnotation] -> Doc
 typeAnnots _ [] = empty
@@ -368,21 +318,18 @@ typeAnnot T.TypeAnnotation{..} =
         Nothing -> empty
         Just v  -> space <> equals <+> literal v
 
-instance Pretty T.TypeAnnotation where
-    pretty = typeAnnot
-
 literal :: Text -> Doc
 literal = cyan . dquotes . text
     -- TODO: escaping?
 
 text :: Text -> Doc
-text = P.text . Text.unpack
+text = PP.text . Text.unpack
 
 reserved :: String -> Doc
-reserved = magenta . P.text
+reserved = magenta . PP.text
 
 op :: String -> Doc
-op = yellow . P.text
+op = yellow . PP.text
 
 declare :: Text -> Doc
 declare = bold . text
@@ -401,7 +348,8 @@ infixr 1 $$
 docstring :: Text -> Doc
 docstring = dullblue . wrapComments . Text.lines
   where
-    wrapComments ls = align . vsep
+    wrapComments [l] = text "/** " <> text l <> " */"
+    wrapComments ls = align . mconcat . List.intersperse hardline
       $ text "/**"
       : map (\l -> text " *" <+> text l) ls
      ++ [text " */"]

--- a/test/Language/Thrift/ParserSpec.hs
+++ b/test/Language/Thrift/ParserSpec.hs
@@ -32,7 +32,7 @@ spec = describe "Parser" $ do
             ]
 
     it "can parse docstrings" $ forM_
-        [ ( return "/** foo */", "foo " )
+        [ ( return "/** foo */", "foo" )
         , ( return "/** foo\n */", "foo" )
         , ( readFile "test/data/docstring-1.txt"
           , "Hello. This is the first\n" ++


### PR DESCRIPTION
The ecosystem seems to be moving towards `prettyprinter`, to the extent that it seems easier to build packages which depend on `prettyprinter`, rather than `ansi-wl-pprint`.

This is a breaking change, by virtue of the removal of Pretty instances.

I think you currently have to choose between backend-specific features or a Pretty instance, with `prettyprinter`.